### PR TITLE
Add name_ja to search candidate list

### DIFF
--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -39,7 +39,7 @@ function search(role, q, limit = 25, excludeIds = new Set()) {
 
   for (const row of list) {
     if (excludeIds.has(row.id)) continue;
-    const cand = [row.ja, row.kana, row.id, ...(row.aliases || [])]
+    const cand = [row.ja, row.name_ja, row.kana, row.id, ...(row.aliases || [])]
       .filter(Boolean)
       .map(normalize);
 


### PR DESCRIPTION
## Summary
- include `row.name_ja` when building search candidates so Japanese names are indexed even if not duplicated in `row.ja`

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbd428b220832089eadca1d29e9e44