### PR TITLE
Add none option for bans with empty query

### DIFF
--- a/src/core/render.js
+++ b/src/core/render.js
@@ -29,6 +29,7 @@ const CHARACTER_NAME_MAP = (() => {
 
 function characterIdToJa(id) {
   if (!id) return '';
+  if (typeof id === 'string' && id.startsWith('ban:none:')) return 'none';
   return CHARACTER_NAME_MAP.get(id) || id;
 }
 


### PR DESCRIPTION
## Summary
- allow blank BAN search modals by making the query optional
- surface a `none` choice when the BAN search is submitted empty and persist that selection with role-specific ids
- render the stored `none` selection as `none` in the rank summary panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbf64376908320b5fe8d58a1996d98