### PR TITLE
Remove duplicate updateMatch import in buttons handler

### DIFF
--- a/src/interactions/buttons.js
+++ b/src/interactions/buttons.js
@@ -17,7 +17,6 @@ const {
   startTraitCooldown,
 } = require('../core/scheduler');
 const { enqueueTokens, stopAll, disconnect } = require('../voice/player');
-const { updateMatch } = require('../db');
 
 // 特質テーブル（抜粋例：実プロジェクトの既存 state.traits を利用してください）
 const NEXT_CT = { // nextサイクル（通常CT）


### PR DESCRIPTION
## Summary
- remove the redundant second `updateMatch` import from the buttons interaction handler so only a single destructuring remains at the top of the file

## Testing
- node - <<'NODE' # simulate a `game:start` button press with stubbed modules to confirm `createMatch` and `updateMatch` fire in sequence
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cd28d745608320a7a67dbe048e83d0