### PR TITLE
Use MessageFlags for ephemeral interaction responses

### DIFF
--- a/src/interactions/buttons.js
+++ b/src/interactions/buttons.js
@@ -211,7 +211,7 @@ async function handle(interaction, client) {
     if (interaction.isButton() || interaction.isStringSelectMenu()) {
       await interaction.deferUpdate();
     } else if (interaction.isModalSubmit()) {
-      await interaction.deferReply({ ephemeral: true });
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
     }
   } catch {}
 
@@ -320,7 +320,7 @@ async function handle(interaction, client) {
       }
     } catch {}
     try {
-      await interaction.followUp({ content: 'VCから切断しました', ephemeral: true });
+      await interaction.followUp({ content: 'VCから切断しました', flags: MessageFlags.Ephemeral });
     } catch (e) {
       console.error('[buttons] failed to send voice disconnect notice', e);
     }

--- a/src/interactions/rank.js
+++ b/src/interactions/rank.js
@@ -10,6 +10,7 @@ const {
   TextInputStyle,
   ActionRowBuilder,
   StringSelectMenuBuilder,
+  MessageFlags,
 } = require('discord.js');
 
 const { updatePanel } = require('../core/render');
@@ -230,7 +231,7 @@ async function openSearchModal(interaction, customId, title) {
 // ---- 候補をエフェメラルのセレクトで提示（最大25件 / 残り枠 = maxValues）
 async function respondCandidates(interaction, state, role, query, maxValues, selectId) {
   if (maxValues <= 0) {
-    await interaction.reply({ content: '枠は埋まっています。', components: [], ephemeral: true });
+    await interaction.reply({ content: '枠は埋まっています。', components: [], flags: MessageFlags.Ephemeral });
     return true;
   }
 
@@ -291,7 +292,7 @@ async function respondCandidates(interaction, state, role, query, maxValues, sel
     await interaction.reply({
       content: '候補が見つかりませんでした。検索語を変えて再試行してください。',
       components: [],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return true;
   }
@@ -307,7 +308,7 @@ async function respondCandidates(interaction, state, role, query, maxValues, sel
   await interaction.reply({
     content: '候補から選択してください。',
     components: [row],
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
   return true;
 }

--- a/src/interactions/selects.js
+++ b/src/interactions/selects.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js');
 const { getGuildState, cancelAllAnnouncements } = require('../core/state');
 const { TRAITS } = require('../core/constants');
 const { convertRemainSec, watcherFromRemain } = require('../core/convert');
@@ -14,19 +15,19 @@ module.exports = {
     const state = getGuildState(guild.id);
 
     if (!state.game.startedAt) {
-      return interaction.reply({ content: '先に「ゲーム開始」を押してください。', ephemeral: true });
+      return interaction.reply({ content: '先に「ゲーム開始」を押してください。', flags: MessageFlags.Ephemeral });
     }
     if (state.game.backcardUsed) {
-      return interaction.reply({ content: '裏向きカードは既に使用済みです。', ephemeral: true });
+      return interaction.reply({ content: '裏向きカードは既に使用済みです。', flags: MessageFlags.Ephemeral });
     }
     if (!state.game.activeTraitKey) {
-      return interaction.reply({ content: 'まずは特質を1回使用し、確定させてください。', ephemeral: true });
+      return interaction.reply({ content: 'まずは特質を1回使用し、確定させてください。', flags: MessageFlags.Ephemeral });
     }
 
     const newKey = interaction.values[0];
     const oldKey = state.game.activeTraitKey;
     if (newKey === oldKey) {
-      return interaction.reply({ content: '同じ特質へは変更できません。', ephemeral: true });
+      return interaction.reply({ content: '同じ特質へは変更できません。', flags: MessageFlags.Ephemeral });
     }
 
     // 旧特質の残りCTを取得（監視者はゲージ換算）
@@ -85,6 +86,6 @@ module.exports = {
       console.warn('panel edit (backcard) failed:', e.message);
     }
 
-    return interaction.reply({ content: `🔁 裏向きカードで **${TRAITS[oldKey].label} → ${TRAITS[newKey].label}** に変更しました。`, ephemeral: true });
+    return interaction.reply({ content: `🔁 裏向きカードで **${TRAITS[oldKey].label} → ${TRAITS[newKey].label}** に変更しました。`, flags: MessageFlags.Ephemeral });
   }
 };


### PR DESCRIPTION
## Summary
- replace interaction response `ephemeral: true` options with `flags: MessageFlags.Ephemeral`
- import MessageFlags anywhere ephemeral replies are sent

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd5a82ae248320959792188adb023a