### PR TITLE
Ensure DB init and logging reliability

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -6,65 +6,102 @@ const pool = new Pool({
   ssl: { rejectUnauthorized: false }, // Supabase は SSL 必須
 });
 
+pool.on('error', (err) => {
+  console.error('[db] pool error:', err);
+});
+
 async function init() {
-  // 起動時に最低限の存在チェック（本番は SQL Editor で作ってある前提）
-  await pool.query(`
-    create extension if not exists pgcrypto;
-    create table if not exists matches (
-      id uuid primary key default gen_random_uuid(),
-      guild_id     text not null,
-      channel_id   text not null,
-      started_at   timestamptz not null,
-      ended_at     timestamptz,
-      mode         text not null check (mode in ('rank','multi')),
-      map          text,
-      bans_surv    text[] default '{}',
-      bans_hunter  text[] default '{}',
-      picks_surv   text[] default '{}',
-      pick_hunter  text,
-      result       text check (result in ('win','draw','lose')),
-      created_by   text,
-      meta         jsonb default '{}'
-    );
-    create index if not exists idx_matches_guild_time on matches (guild_id, started_at desc);
-  `);
-  console.log('[db] init ok');
+  try {
+    // 起動時に最低限の存在チェック（本番は SQL Editor で作ってある前提）
+    await pool.query(`
+      create extension if not exists pgcrypto;
+      create table if not exists matches (
+        id uuid primary key default gen_random_uuid(),
+        guild_id     text not null,
+        channel_id   text not null,
+        started_at   timestamptz not null,
+        ended_at     timestamptz,
+        mode         text not null check (mode in ('rank','multi')),
+        map          text,
+        bans_surv    text[] default '{}',
+        bans_hunter  text[] default '{}',
+        picks_surv   text[] default '{}',
+        pick_hunter  text,
+        result       text check (result in ('win','draw','lose')),
+        created_by   text,
+        meta         jsonb default '{}'
+      );
+      create index if not exists idx_matches_guild_time on matches (guild_id, started_at desc);
+    `);
+    console.log('[db] init ok');
+  } catch (err) {
+    console.error('[db] init failed:', err);
+    throw err;
+  }
 }
 
 async function createMatch({ guildId, channelId, mode, createdBy }) {
-  const res = await pool.query(
-    `insert into matches (guild_id, channel_id, started_at, mode, created_by)
-     values ($1,$2, now(), $3, $4) returning id`,
-    [guildId, channelId, mode, createdBy || null]
-  );
-  return res.rows[0].id;
+  try {
+    const res = await pool.query(
+      `insert into matches (guild_id, channel_id, started_at, mode, created_by)
+       values ($1,$2, now(), $3, $4) returning id`,
+      [guildId, channelId, mode, createdBy || null]
+    );
+    const id = res.rows[0].id;
+    console.log('[db] createMatch ok:', id);
+    return id;
+  } catch (err) {
+    console.error('[db] createMatch failed:', err);
+    throw err;
+  }
 }
 
 async function updateMatch(id, patch) {
-  // 可変更新：渡されたキーだけ更新
-  const fields = [];
-  const vals = [];
-  let idx = 1;
-  for (const [k, v] of Object.entries(patch)) {
-    fields.push(`${k} = $${idx++}`);
-    vals.push(v);
+  try {
+    // 可変更新：渡されたキーだけ更新
+    const fields = [];
+    const vals = [];
+    let idx = 1;
+    for (const [k, v] of Object.entries(patch)) {
+      fields.push(`${k} = $${idx++}`);
+      vals.push(v);
+    }
+    if (!fields.length) {
+      console.log('[db] updateMatch skipped (no fields):', id);
+      return;
+    }
+    vals.push(id);
+    const sql = `update matches set ${fields.join(', ')} where id = $${idx}`;
+    await pool.query(sql, vals);
+    console.log('[db] updateMatch ok:', id);
+  } catch (err) {
+    console.error('[db] updateMatch failed:', err);
+    throw err;
   }
-  if (!fields.length) return;
-  vals.push(id);
-  const sql = `update matches set ${fields.join(', ')} where id = $${idx}`;
-  await pool.query(sql, vals);
 }
 
 async function closeMatch(id) {
-  await pool.query(`update matches set ended_at = now() where id = $1`, [id]);
+  try {
+    await pool.query(`update matches set ended_at = now() where id = $1`, [id]);
+    console.log('[db] closeMatch ok:', id);
+  } catch (err) {
+    console.error('[db] closeMatch failed:', err);
+    throw err;
+  }
 }
 
 async function getRecentMatches(guildId, limit = 20) {
-  const res = await pool.query(
-    `select * from matches where guild_id = $1 order by started_at desc limit $2`,
-    [guildId, limit]
-  );
-  return res.rows;
+  try {
+    const res = await pool.query(
+      `select * from matches where guild_id = $1 order by started_at desc limit $2`,
+      [guildId, limit]
+    );
+    console.log('[db] getRecentMatches ok:', guildId, `(${res.rows.length})`);
+    return res.rows;
+  } catch (err) {
+    console.error('[db] getRecentMatches failed:', err);
+    throw err;
+  }
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -6,56 +6,66 @@ const { Client, GatewayIntentBits, Events, Partials } = require('discord.js');
 const setupCmd = require('./commands/setup');
 const buttonHandler = require('./interactions/buttons');
 const { startScheduler } = require('./core/scheduler');
+const { init } = require('./db');
 
-// HTTP server (Render)
-const app = express();
-app.get('/', (_req, res) => res.status(200).send('ok'));
-app.get('/healthz', (_req, res) => res.status(200).json({ ok: true, uptime: process.uptime() }));
-app.get('/favicon.ico', (_req, res) => res.sendStatus(204));
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`HTTP server listening on :${PORT}`));
-
-// Discord client
-const client = new Client({
-  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates],
-  partials: [Partials.Channel],
-});
-
-client.once(Events.ClientReady, (c) => {
-  console.log(`Logged in as ${c.user.tag}`);
-  startScheduler(client); // no-op (互換)
-});
-
-// /setup と すべての UI（ボタン/セレクト/モーダル）を buttons ハンドラへ
-client.on(Events.InteractionCreate, async (interaction) => {
+(async () => {
   try {
-    if (interaction.isChatInputCommand()) {
-      if (interaction.commandName === 'setup') {
-        return setupCmd.execute(interaction);
-      }
-    } else if (
-      interaction.isButton() ||
-      interaction.isStringSelectMenu() ||
-      interaction.isModalSubmit()
-    ) {
-      return buttonHandler.handle(interaction, client);
-    }
-  } catch (e) {
-    console.error('Interaction error:', e);
-    try {
-      if (interaction.isRepliable()) {
-        await interaction.reply({ content: 'エラーが発生しました。', flags: 64 });
-      }
-    } catch {}
+    await init();
+  } catch (err) {
+    console.error('[startup] db init failed:', err);
+    process.exit(1);
   }
-});
 
-const token = process.env.DISCORD_TOKEN;
-if (!token) {
-  console.error('DISCORD_TOKEN が設定されていません。環境変数を確認してください。');
-  process.exit(1);
-}
-client.login(token);
+  // HTTP server (Render)
+  const app = express();
+  app.get('/', (_req, res) => res.status(200).send('ok'));
+  app.get('/healthz', (_req, res) => res.status(200).json({ ok: true, uptime: process.uptime() }));
+  app.get('/favicon.ico', (_req, res) => res.sendStatus(204));
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => console.log(`HTTP server listening on :${PORT}`));
+
+  // Discord client
+  const client = new Client({
+    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates],
+    partials: [Partials.Channel],
+  });
+
+  client.once(Events.ClientReady, (c) => {
+    console.log(`Logged in as ${c.user.tag}`);
+    startScheduler(client); // no-op (互換)
+  });
+
+  // /setup と すべての UI（ボタン/セレクト/モーダル）を buttons ハンドラへ
+  client.on(Events.InteractionCreate, async (interaction) => {
+    try {
+      if (interaction.isChatInputCommand()) {
+        if (interaction.commandName === 'setup') {
+          return setupCmd.execute(interaction);
+        }
+      } else if (
+        interaction.isButton() ||
+        interaction.isStringSelectMenu() ||
+        interaction.isModalSubmit()
+      ) {
+        return buttonHandler.handle(interaction, client);
+      }
+    } catch (e) {
+      console.error('Interaction error:', e);
+      try {
+        if (interaction.isRepliable()) {
+          await interaction.reply({ content: 'エラーが発生しました。', flags: 64 });
+        }
+      } catch {}
+    }
+  });
+
+  const token = process.env.DISCORD_TOKEN;
+  if (!token) {
+    console.error('DISCORD_TOKEN が設定されていません。環境変数を確認してください。');
+    process.exit(1);
+  }
+  client.login(token);
+})();
 
 process.on('unhandledRejection', (r) => console.error('[unhandledRejection]', r));
 process.on('uncaughtException', (e) => console.error('[uncaughtException]', e));


### PR DESCRIPTION
## Summary
- await the database init during startup before registering Discord handlers and exit on failure
- add defensive logging and error handling to every exported database helper and listen for pool errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5ae9c658832087d85fb773ed161a