### PR TITLE
Add mode validation before match creation

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -31,7 +31,14 @@ async function init() {
   console.log('[db] init ok');
 }
 
+function assertMode(mode) {
+  if (!['rank', 'multi'].includes(mode)) {
+    throw new Error(`[db] invalid mode: ${mode} (allowed: 'rank'|'multi')`);
+  }
+}
+
 async function createMatch({ guildId, channelId, mode, createdBy }) {
+  assertMode(mode);
   const res = await pool.query(
     `insert into matches (guild_id, channel_id, started_at, mode, created_by)
      values ($1,$2, now(), $3, $4) returning id`,


### PR DESCRIPTION
## Summary
- add an assertMode helper to validate match modes
- guard createMatch by rejecting unexpected mode strings before inserting

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd5af9dd688320817bf7048bd4dc39