### PR TITLE
feat(voice): support env fallback for kaidoku token

### DIFF
--- a/src/voice/player.js
+++ b/src/voice/player.js
@@ -12,6 +12,7 @@ const {
   demuxProbe,
 } = require('@discordjs/voice');
 const { defaultDir } = require('../core/bootstrapAudio');
+const { getVoiceToken } = require('./token');
 
 const AUDIO_DIR = process.env.AUDIO_DIR || defaultDir;
 const GAP_MS = Number.isFinite(Number(process.env.VOICE_GAP_MS))
@@ -137,7 +138,7 @@ function enqueueTokens(guildId, tokens) {
   for (const t of tokens) {
     const p = audioPath(t);
     if (p) files.push(p);
-    else console.warn(`[voice] missing token file: ${t}`);
+    else if (!getVoiceToken(t)) console.warn(`[voice] missing token file: ${t}`);
   }
   if (files.length === 0) return;
   ensureQueue(guildId).push(...files);

--- a/src/voice/token.js
+++ b/src/voice/token.js
@@ -1,0 +1,42 @@
+// src/voice/token.js
+const tokenCache = new Map();
+
+function loadToken({ envKey, filePath, label }) {
+  const fs = require('fs');
+  let t = process.env[envKey];
+  if (!t && filePath && fs.existsSync(filePath)) {
+    t = fs.readFileSync(filePath, 'utf8').trim();
+  }
+  if (!t) console.warn(`[voice] missing token for ${label || envKey}`);
+  return t;
+}
+
+const TOKEN_LOADERS = {
+  kaidoku_kasoku: () =>
+    loadToken({
+      envKey: 'KAIDOKU_KASOKU_TOKEN',
+      filePath: '/etc/secrets/kaidoku_kasoku',
+      label: 'kaidoku_kasoku',
+    }),
+};
+
+function getVoiceToken(name, { reload = false } = {}) {
+  const loader = TOKEN_LOADERS[name];
+  if (!loader) return null;
+  if (reload || !tokenCache.has(name)) {
+    const value = loader();
+    tokenCache.set(name, value ?? null);
+  }
+  return tokenCache.get(name);
+}
+
+function clearVoiceToken(name) {
+  if (typeof name === 'string') tokenCache.delete(name);
+  else tokenCache.clear();
+}
+
+module.exports = {
+  loadToken,
+  getVoiceToken,
+  clearVoiceToken,
+};


### PR DESCRIPTION
## Summary
- add a reusable `loadToken` helper for voice secrets with env var fallback and optional caching utilities
- update the voice player queue logic to consult the helper before warning about missing kaidoku_kasoku audio so environments with the secret avoid spurious logs

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd5b5a52e4832083974e90e9ec3bd9