### PR TITLE
Fix voice token name for kaitoku kasoku

### DIFF
--- a/src/interactions/buttons.js
+++ b/src/interactions/buttons.js
@@ -192,8 +192,8 @@ function scheduleMatchStart(client, state) {
     const delay = Math.max(0, Math.ceil(wait));
     setTimeout(() => {
       if (!state.matchActive) return;
-      if (sec === 0) enqueueTokens(state.guildId, ['kaidoku_kasoku', 'hatsudou']); // 任意の音声構成
-      else enqueueTokens(state.guildId, ['kaidoku_kasoku', 'nokori', `${sec}byo`]);
+      if (sec === 0) enqueueTokens(state.guildId, ['kaitoku_kasoku', 'hatsudou']); // 任意の音声構成
+      else enqueueTokens(state.guildId, ['kaitoku_kasoku', 'nokori', `${sec}byo`]);
     }, delay);
   };
   for (const m of [60, 30, 0]) notify(m);

--- a/src/voice/token.js
+++ b/src/voice/token.js
@@ -12,11 +12,11 @@ function loadToken({ envKey, filePath, label }) {
 }
 
 const TOKEN_LOADERS = {
-  kaidoku_kasoku: () =>
+  kaitoku_kasoku: () =>
     loadToken({
-      envKey: 'KAIDOKU_KASOKU_TOKEN',
-      filePath: '/etc/secrets/kaidoku_kasoku',
-      label: 'kaidoku_kasoku',
+      envKey: 'KAITOKU_KASOKU_TOKEN',
+      filePath: '/etc/secrets/kaitoku_kasoku',
+      label: 'kaitoku_kasoku',
     }),
 };
 


### PR DESCRIPTION
## Summary
- rename the queued audio token in the match acceleration notifier to `kaitoku_kasoku`
- update the voice token loader to use the corrected `kaitoku_kasoku` identifiers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd66f876708320b833e64a2d2e91dc